### PR TITLE
Ubuntu installer fix parameters

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -15,20 +15,20 @@ clear
 tempdir=$(mktemp -d)
 
 
-apt-get install ttf-mscorefonts-installer -y 
-apt-get install ubuntu-restricted-addons -y 
-apt-get install gstreamer0.10-plugins-bad-multiverse -y 
-apt-get install libavcodec-extra-53 -y 
-apt-get install unrar gnome-icon-theme-full -y
+apt-get -y install ttf-mscorefonts-installer
+apt-get -y install ubuntu-restricted-addons
+apt-get -y install gstreamer0.10-plugins-bad-multiverse
+apt-get -y install libavcodec-extra-53
+apt-get -y install unrar gnome-icon-theme-full
 
-add-apt-repository ppa:yorba/ppa -y 
-add-apt-repository ppa:smathot/cogscinl -y 
-add-apt-repository ppa:gottcode/gcppa -y 
-add-apt-repository ppa:webupd8team/sublime-text-2 -y 
+add-apt-repository -y  ppa:yorba/ppa
+add-apt-repository -y  ppa:smathot/cogscinl
+add-apt-repository -y  ppa:gottcode/gcppa
+add-apt-repository -y  ppa:webupd8team/sublime-text-2
 echo "Updating"
 apt-get update &> /dev/null
 
-apt-get install sublime-text focuswriter opensesame vlc libreoffice firefox texlive -y || echo "Writers and Firefox not installed"
+apt-get -y install sublime-text focuswriter opensesame vlc libreoffice firefox texlive || echo "Writers and Firefox not installed"
 apt-get -y build-dep libcurl4-gnutls-dev
 apt-get -y install libcurl4-gnutls-dev
 

--- a/installer.sh
+++ b/installer.sh
@@ -34,14 +34,14 @@ apt-get -y install libcurl4-gnutls-dev
 
 
 
-apt-get upgrade && echo "Actualización correcta" || echo "Actualización fallida"
+apt-get -y upgrade && echo "Actualización correcta" || echo "Actualización fallida"
 
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
 
 echo "deb http://cran.r-project.org/bin/linux/ubuntu trusty/" >>  /etc/apt/sources.list
 echo "updating"
 apt-get update &> /dev/null
-apt-get install r-base
+apt-get -y install r-base
 
 
 cat << EOF > $tempdir/sc.R
@@ -72,4 +72,4 @@ rm -fr $tempdir
 
 
 
-apt-get upgrade || echo "Upgrade failed" && echo "Upgrade OK"
+apt-get -y upgrade || echo "Upgrade failed" && echo "Upgrade OK"

--- a/installer.sh
+++ b/installer.sh
@@ -36,7 +36,7 @@ apt-get -y install libcurl4-gnutls-dev
 
 apt-get upgrade && echo "Actualización correcta" || echo "Actualización fallida"
 
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9 -y
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
 
 echo "deb http://cran.r-project.org/bin/linux/ubuntu trusty/" >>  /etc/apt/sources.list
 echo "updating"


### PR DESCRIPTION
Fixes:

- Wrong `-y` switch with `apt-key`.
- Missing `-y` switch with some `apt-get`.
- Move `-y` switches to their recommended position according to documentation.